### PR TITLE
Fixing Permission related issue. Fixes #11

### DIFF
--- a/app/src/main/res/layout/fragment_trip_empty.xml
+++ b/app/src/main/res/layout/fragment_trip_empty.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    tools:context="com.ae.apps.tripmeter.fragments.TripsListFragment">
+
+    <TextView
+        android:id="@+id/contacts_access"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:drawablePadding="@dimen/fab_margin"
+        android:gravity="center"
+        android:text="@string/str_permission_contacts_reason"
+        android:visibility="gone" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,9 @@
 
     <string name="pref_title_vibrate">Vibrate</string>
 
+    <string name="str_perm_title">Permission Needed</string>
+    <string name="str_perm_reason">Contacts access is needed for this feature</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,8 +134,8 @@
 
     <string name="pref_title_vibrate">Vibrate</string>
 
-    <string name="str_perm_title">Permission Needed</string>
-    <string name="str_perm_reason">Contacts access is needed for this feature</string>
+    <string name="str_permission_title">Permission Needed</string>
+    <string name="str_permission_contacts_reason">Contacts access is needed for this feature</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>


### PR DESCRIPTION
Support for Android M & above.
**EDIT:Update of tasks**
**Summary of Changes Requested:**

- [x] Rename String values to str_permission_contacts_reason and such to allow multiple values.

- [x] On entering to the expenses fragment if permission is already granted paint the normal view.If permission is to be requested paint a empty view.

- [x] onRequestPermissionsResult()
PERMISSION_GRANTED -> inflate(R.layout.fragment_trips_list, container, false); and add to view// we could cache the inflator
PERMISSION_DENIED -> view.add(new TextView()); // add to empty view already created

Two important tasks remain before merging related to transition of fragments for user. 

In onRequestPermissionsResult we need to handle both probable cases (allow & deny).

Now the app won't crash but on denying/allowing it would remain in the same fragment and there would be no possible action for user to do as the view was rendered without FloatingActionButton being binded to action.

Expected: On allow we need to re-render fragment and on denial move to Price tab.
I will need help on implementing this as the options I tried did not work perfectly.

Updated Screenshots: Android N

![screenshot_1488898778](https://cloud.githubusercontent.com/assets/7160211/23664929/10e03ab6-037d-11e7-9380-a9613c1a0342.png)
![screenshot_1488899091](https://cloud.githubusercontent.com/assets/7160211/23664993/3cf15284-037d-11e7-9454-f9f8d9d1e8e1.png)
![screenshot_1488899083](https://cloud.githubusercontent.com/assets/7160211/23664995/3d133c00-037d-11e7-94c9-f328babc8207.png)

